### PR TITLE
Add slit-scan panorama generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+__pycache__/
+*.pyc
+pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Slitscan Panorama Builder
+
+This project processes a side-window video to estimate motion and build a panoramic image.
+
+## Usage
+
+```bash
+python -m slitscan <video path> --output panorama.png
+```
+
+The script estimates the average horizontal speed and direction of the scene using optical flow. It extracts vertical strips at regular distances and stitches them into a panorama image.
+
+Dependencies are listed in `requirements.txt`.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+opencv-python-headless
+numpy

--- a/slitscan/__init__.py
+++ b/slitscan/__init__.py
@@ -1,0 +1,5 @@
+"""Slitscan panorama builder."""
+
+from .panorama import process_video
+
+__all__ = ["process_video"]

--- a/slitscan/__main__.py
+++ b/slitscan/__main__.py
@@ -1,0 +1,30 @@
+import argparse
+from .panorama import process_video
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Build a slit-scan panorama from a video")
+    parser.add_argument("video", help="Path to input video")
+    parser.add_argument("--output", default="panorama.png", help="Output panorama filename")
+    parser.add_argument("--strip-width", type=int, default=2, help="Width of each strip in pixels")
+    parser.add_argument(
+        "--strip-spacing",
+        type=float,
+        default=20.0,
+        help="Horizontal displacement between strips in pixels",
+    )
+    args = parser.parse_args()
+
+    result = process_video(
+        args.video,
+        strip_width=args.strip_width,
+        strip_spacing=args.strip_spacing,
+        output=args.output,
+    )
+
+    print(f"Estimated speed: {result.speed:.2f} px/s, direction: {result.direction}")
+    print(f"Panorama saved to {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/slitscan/panorama.py
+++ b/slitscan/panorama.py
@@ -1,0 +1,100 @@
+import cv2
+import numpy as np
+from dataclasses import dataclass
+
+
+@dataclass
+class MotionResult:
+    """Estimated motion parameters."""
+    speed: float  # pixels per second
+    direction: str  # 'left' or 'right'
+
+
+def process_video(
+    video_path: str,
+    strip_width: int = 2,
+    strip_spacing: float = 20.0,
+    output: str = "panorama.png",
+) -> MotionResult:
+    """Process ``video_path`` to build a panorama image.
+
+    Parameters
+    ----------
+    video_path:
+        Path to input video file.
+    strip_width:
+        Width of each vertical strip in pixels.
+    strip_spacing:
+        Required horizontal displacement (in pixels) between strips.
+    output:
+        Filename where the panorama image will be written.
+
+    Returns
+    -------
+    MotionResult
+        Estimated speed (pixels/second) and direction.
+    """
+
+    cap = cv2.VideoCapture(video_path)
+    if not cap.isOpened():
+        raise ValueError(f"Cannot open video: {video_path}")
+
+    fps = cap.get(cv2.CAP_PROP_FPS) or 30.0
+
+    ret, prev_frame = cap.read()
+    if not ret:
+        raise ValueError("Empty video")
+
+    prev_gray = cv2.cvtColor(prev_frame, cv2.COLOR_BGR2GRAY)
+    height, width = prev_frame.shape[:2]
+
+    strips = []
+    distance_acc = 0.0
+    flow_x_total = 0.0
+    frame_count = 0
+
+    while True:
+        ret, frame = cap.read()
+        if not ret:
+            break
+        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
+
+        flow = cv2.calcOpticalFlowFarneback(
+            prev_gray,
+            gray,
+            None,
+            pyr_scale=0.5,
+            levels=3,
+            winsize=15,
+            iterations=3,
+            poly_n=5,
+            poly_sigma=1.2,
+            flags=0,
+        )
+
+        mean_flow_x = flow[..., 0].mean()
+        distance_acc += abs(mean_flow_x)
+        flow_x_total += mean_flow_x
+        frame_count += 1
+
+        if distance_acc >= strip_spacing:
+            x = width // 2
+            strip = frame[:, x : x + strip_width]
+            strips.append(strip)
+            distance_acc = 0.0
+
+        prev_gray = gray
+
+    cap.release()
+
+    if strips:
+        panorama = np.hstack(strips)
+        cv2.imwrite(output, panorama)
+
+    avg_flow_x = flow_x_total / frame_count if frame_count else 0.0
+    speed = abs(avg_flow_x) * fps
+    direction = "right" if avg_flow_x > 0 else "left"
+    return MotionResult(speed=speed, direction=direction)
+
+
+__all__ = ["process_video", "MotionResult"]

--- a/tests/test_panorama.py
+++ b/tests/test_panorama.py
@@ -1,0 +1,32 @@
+import cv2
+import numpy as np
+from pathlib import Path
+import sys
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+from slitscan import process_video
+
+
+def create_synthetic_video(path: Path, frames: int = 20, fps: int = 10) -> None:
+    width, height = 60, 40
+    fourcc = cv2.VideoWriter_fourcc(*"mp4v")
+    writer = cv2.VideoWriter(str(path), fourcc, fps, (width, height))
+
+    frame = np.zeros((height, width, 3), dtype=np.uint8)
+    cv2.rectangle(frame, (10, 10), (20, 30), (255, 255, 255), -1)
+    for _ in range(frames):
+        writer.write(frame)
+        frame = np.roll(frame, -1, axis=1)  # shift left
+    writer.release()
+
+
+def test_process_video(tmp_path: Path):
+    video_file = tmp_path / "input.mp4"
+    out_file = tmp_path / "pano.png"
+    create_synthetic_video(video_file)
+
+    result = process_video(str(video_file), strip_width=2, strip_spacing=5, output=str(out_file))
+
+    assert result.direction == "left"
+    assert result.speed > 0
+    assert out_file.exists()


### PR DESCRIPTION
## Summary
- Add slit-scan panorama builder using optical flow to stitch vertical strips
- Provide CLI entry point to process side-window videos
- Include synthetic video test and requirements

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f8150db308326a4e35d268f378705