### PR TITLE
Use median flow for robust background motion

### DIFF
--- a/slitscan/panorama.py
+++ b/slitscan/panorama.py
@@ -72,9 +72,12 @@ def process_video(
             flags=0,
         )
 
-        mean_flow_x = flow[..., 0].mean()
-        distance_acc += abs(mean_flow_x)
-        flow_x_total += mean_flow_x
+        # Use the median flow to emphasise background motion and
+        # reduce the impact of fast moving foreground objects which can
+        # otherwise compress the panorama due to parallax.
+        median_flow_x = np.median(flow[..., 0])
+        distance_acc += abs(median_flow_x)
+        flow_x_total += median_flow_x
         frame_count += 1
 
         if distance_acc >= strip_spacing:


### PR DESCRIPTION
## Summary
- Reduce parallax influence by using median optical flow to track background motion
- Document why median flow helps prevent panorama compression from fast moving foreground objects

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688f905fe9d0832697a54e1b5717f5a4